### PR TITLE
feat: change minimum go version from 1.25.0 to 1.24.0

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,6 +1,7 @@
 package compositeactionlint
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,9 +19,12 @@ func TestCommandMain_Ok(t *testing.T) {
 
 	for _, filepath := range files {
 		t.Run(filepath, func(t *testing.T) {
-			c := Command{Stdout: t.Output(), Stderr: t.Output()}
+			// Replace with t.Output() from go 1.25
+			var testOut bytes.Buffer
+			c := Command{Stdout: &testOut, Stderr: &testOut}
 			exitCode := c.Main([]string{argv0, filepath})
 
+			t.Log(testOut.String())
 			assert.Equal(t, 0, exitCode)
 		})
 	}
@@ -35,9 +39,12 @@ func TestCommandMain_BadActions(t *testing.T) {
 
 	for _, filepath := range files {
 		t.Run(filepath, func(t *testing.T) {
-			c := Command{Stdout: t.Output(), Stderr: t.Output()}
+			// Replace with t.Output() from go 1.25
+			var testOut bytes.Buffer
+			c := Command{Stdout: &testOut, Stderr: &testOut}
 			exitCode := c.Main([]string{argv0, filepath})
 
+			t.Log(testOut.String())
 			assert.Equal(t, 1, exitCode)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bettermarks/composite-action-lint
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/rhysd/actionlint v1.7.7


### PR DESCRIPTION
Changed the minimum required `go` version from `1.25.0` to `1.24.0` to support more OS releases (eg: current _Fedora 42_ 
only provides `go 1.24.6`).

**How has this been tested?**
- Built locally
