### PR TITLE
ci: provide composite action and check it using itself

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
-      - uses: ./
-        with:
+      - uses: ./ # use the checked out version of this repo as an action
+        with: # to lint the composite action it provides
           actions: 'action.yml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go vet ./...
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       # https://github.com/golangci/golangci-lint-action
@@ -37,3 +37,11 @@ jobs:
         with:
           version: "${{ env.GOLANGCI_LINT_VERSION }}"
           args: --timeout=5m --tests=false ./...
+
+  action:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./
+        with:
+          actions: 'action.yml'

--- a/README.md
+++ b/README.md
@@ -2,15 +2,38 @@ composite-action-lint
 =====================
 
 
-A shallow structural copy of [actionlint][actionlint-repo] but instead for
-linting the steps of [composite github actions][composite-action-tutorial]
-instead of github workflow files.
+A shallow structural copy of [actionlint][actionlint-repo] 
+but for linting the steps of [composite github actions][composite-action-tutorial]
+instead of workflow files.
 
 
 Significant portions of actionlint have been copied verbatim or with minor
 changes. The actionlint license is included at
 [ACTIONLINT_LICENSE.txt](./ACTIONLINT_LICENSE.txt)
 
+
+## Usage
+
+### in a workflow
+
+Keep in mind: if you don't have any composite actions in your repo, you don't need this action.
+
+```yaml
+name: actionlint
+on:
+  pull_request:
+    paths:
+      - .github/**
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: bettermarks/composite-action-lint@main
+        with:
+          actions: .github/actions/*/action.yml # this is the default value, so it can be omitted
+```
 
 ## Installation
 
@@ -26,6 +49,7 @@ Then ensure you have `$(go env GOPATH)/bin` on your `PATH`.
 
 Unlike actionlint, composite-action-lint does not search for actions to lint.
 Pass each action metadata file as an argument to composite-action-lint
+If the path does not point to an action file the command will fail.
 
 ```shell
 composite-action-lint path/to-action/action.yml and/another/action.yaml

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,22 @@
+name: composite-action-lint
+
+description: actionlint for composite actions
+
+inputs:
+  actions:
+    description: paths to actions to lint, supports wildcards
+    default: .github/actions/*/action.yml
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v6
+      with:
+        go-version: 'stable'
+    - name: Install composite-action-lint
+      run: go install github.com/bettermarks/composite-action-lint/cmd/composite-action-lint@latest
+      shell: sh
+    - name: Check composite actions
+      run: composite-action-lint ${{ inputs.actions }}
+      shell: sh

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: actionlint for composite actions
 
 inputs:
   actions:
-    description: paths to actions to lint, supports wildcards
+    description: space separated list of paths to actions to lint, supports wildcards
     default: .github/actions/*/action.yml
     required: false
 


### PR DESCRIPTION
By adding `action.yml` to the top level, this repo can be used as a (composite :stuck_out_tongue_winking_eye: ) action, without having to know that is uses go under the hood.

Of course we eat the dog food: added a job to the github workflow that uses itself as an action to lint the `action.yml` file.

Additionally I tested the action from the current branch in https://github.com/bettermarks/bm-mifro/pull/6020:
https://github.com/bettermarks/bm-mifro/actions/runs/18707305637/job/53347709077?pr=6020
